### PR TITLE
Fixed swapped loadouts for UAV operator and jet pilot on loadout boards

### DIFF
--- a/adv_missiontemplate.altis/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.altis/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.chernarus/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.chernarus/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.chernarus_summer/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.chernarus_summer/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.clafghan/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.clafghan/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.malden/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.malden/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.sara/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.sara/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.stratis/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.stratis/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.takistan/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.takistan/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.tanoa/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.tanoa/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_missiontemplate.zargabad/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_missiontemplate.zargabad/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_opfortemplate.tanoa/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_opfortemplate.tanoa/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_ussfreedomtemplate.altis/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_ussfreedomtemplate.altis/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_ussfreedomtemplate.chernarus_summer/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_ussfreedomtemplate.chernarus_summer/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_ussfreedomtemplate.stratis/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_ussfreedomtemplate.stratis/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];

--- a/adv_ussfreedomtemplate.tanoa/functions/gear/internal/fn_dialogGearInit.sqf
+++ b/adv_ussfreedomtemplate.tanoa/functions/gear/internal/fn_dialogGearInit.sqf
@@ -134,8 +134,8 @@ if (side (group player) isEqualTo west) then {
 	lbSetData [7377, 20, "['ADV_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_FNC_JETPILOT','']"];
-	lbSetData [7377, 24, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_FNC_DRIVER','']"];
@@ -172,8 +172,8 @@ if (side (group player) isEqualTo independent) then {
 	lbSetData [7377, 20, "['ADV_IND_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_IND_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_IND_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_IND_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_IND_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_IND_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_IND_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_IND_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_IND_FNC_DRIVER','']"];
@@ -210,8 +210,8 @@ if (side (group player) isEqualTo east) then {
 	lbSetData [7377, 20, "['ADV_OPF_FNC_SPEC','']"];
 	lbSetData [7377, 21, "['ADV_OPF_FNC_SPEC','EOD']"];
 	lbSetData [7377, 22, "['ADV_OPF_FNC_MARKSMAN','']"];
-	lbSetData [7377, 23, "['ADV_OPF_FNC_JETPILOT','']"];
-	lbSetData [7377, 25, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 23, "['ADV_OPF_FNC_UAVOP','']"];
+	lbSetData [7377, 24, "['ADV_OPF_FNC_JETPILOT','']"];
 	lbSetData [7377, 26, "['ADV_OPF_FNC_LOG','']"];
 	lbSetData [7377, 27, "['ADV_OPF_FNC_SPEC','REPAIR']"];
 	lbSetData [7377, 28, "['ADV_OPF_FNC_DRIVER','']"];


### PR DESCRIPTION
The loadout boards initialisation swapped the loadouts of the UAV oeprator and jet pilot, equipping the soldier with the "opposite" loadout than selected.
Furthermore, the `independent` and `opfor` loadout boards had an off-by-one error for the same loadouts, assigning the loadouts to index 25, which is the `---- Logistikloadouts ----` separator.

Both issues have been fixed for all templates in the repo.